### PR TITLE
Add the packaging metadata to build the uport-wallet-cli snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: uport-wallet-cli
+version: git
+summary: Cli ether and ERC20 wallet for uport
+description: |
+  Self-sovereign ID enables you to collect verifications, log-in without
+  passwords, digitally sign transactions, and interact with Ethereum
+  applications.
+
+apps:
+  uport-wallet-cli:
+    command: uport-wallet-cli
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  uport-wallet-cli:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This package will let you publish the latest uport-wallet-cli in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.